### PR TITLE
diagnostic.py: Correct row and column number convention

### DIFF
--- a/coala_langserver/diagnostic.py
+++ b/coala_langserver/diagnostic.py
@@ -20,17 +20,32 @@ def output_to_diagnostics(output):
             origin = problem['origin']
             real_message = '[{}] {}: {}'.format(section, origin, message)
             for code in problem['affected_code']:
+                """
+                Line position and character offset should be zero-based
+                according to LSP, but row and column positions of coala
+                are None or one-based number.
+                coala uses None for convenience. None for column means the
+                whole line while None for line means the whole file.
+                """
+                def convert_offset(x): return x - 1 if x else x
+                start_line = convert_offset(code['start']['line'])
+                start_char = convert_offset(code['start']['column'])
+                end_line = convert_offset(code['end']['line'])
+                end_char = convert_offset(code['end']['column'])
+                if start_char is None or end_char is None:
+                    start_char = 0
+                    end_line = start_line + 1
+                    end_char = 0
                 res.append({
                     'severity': severity,
                     'range': {
                         'start': {
-                            # Trick: VS Code starts from 0?
-                            'line': code['start']['line'] - 1,
-                            'character': code['start']['column']
+                            'line': start_line,
+                            'character': start_char
                         },
                         'end': {
-                            'line': code['end']['line'] - 1,
-                            'character': code['end']['column']
+                            'line': end_line,
+                            'character': end_char
                         }
                     },
                     'source': 'coala',


### PR DESCRIPTION
Row and column number should be zero-based integer, not null

Fixes https://github.com/coala/coala-vs-code/issues/37