### PR TITLE
.rultor.yml: Remove unused config

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -1,3 +1,0 @@
-merge:
-  fast-forward: only
-  script: echo "Nothing to do."


### PR DESCRIPTION
Rultor is not used by coala any longer.

Related to https://github.com/coala/coala/issues/5328